### PR TITLE
[codex] fix bilibili seek playback

### DIFF
--- a/ffvideo/bv.py
+++ b/ffvideo/bv.py
@@ -36,6 +36,37 @@ ffmpeg_jobs_dict = {
 }
 ffmpeg_jobs = FFMPEGJobs(**ffmpeg_jobs_dict)
 
+
+def get_output_video_path(bvid, cid, start_ms=0):
+    if start_ms > 0:
+        return f'/tmp/bv_output_{bvid}_{cid}_{start_ms}.flv'
+    return f'/tmp/bv_output_{bvid}_{cid}.flv'
+
+
+def wait_for_output_file(output_video_path, timeout=30):
+    start_time = time.time()
+    while True:
+        if os.path.exists(output_video_path):
+            return True
+        if time.time() - start_time > timeout:
+            return False
+        time.sleep(0.1)
+
+
+def stop_current_jobs():
+    global ffmpeg_jobs
+    ffmpeg_jobs.stop_event.set()
+    for task in ffmpeg_jobs.tasks:
+        task.join()
+    ffmpeg_jobs.tasks = []
+
+
+def make_ffmpeg_headers():
+    header_lines = []
+    for key, value in HEADERS.items():
+        header_lines.append(f'{key}: {value}')
+    return '\r\n'.join(header_lines) + '\r\n'
+
 def add_bv_route(app):
 
     @app.route('/api/bilibili/rank', methods=['GET'])
@@ -132,6 +163,58 @@ def add_bv_route(app):
             logger.info(f'ret code:{return_code}, write done file')
         else:
             logger.warning(f'ffmpeg error exit, code:{return_code}')
+
+    def ffmpeg_seek_streams(video_url, audio_url, output_video_path, start_ms):
+        global ffmpeg_jobs
+
+        DONE_FILE = f'{output_video_path}.done'
+        if os.path.exists(DONE_FILE):
+            os.remove(DONE_FILE)
+        if os.path.exists(output_video_path):
+            os.remove(output_video_path)
+
+        start_sec = max(start_ms / 1000.0, 0)
+        ffmpeg_cmd = [
+            FFMPEG_PATH,
+            '-headers', make_ffmpeg_headers(),
+            '-ss', str(start_sec),
+            '-i', video_url,
+            '-headers', make_ffmpeg_headers(),
+            '-ss', str(start_sec),
+            '-i', audio_url,
+            '-c:v', 'libx264',
+            '-x264-params', 'keyint=30:scenecut=0',
+            '-c:a', 'copy',
+            '-f', 'flv',
+            output_video_path,
+            '-y'
+        ]
+
+        logger.info(f'cmd:{ffmpeg_cmd}')
+        process = subprocess.Popen(ffmpeg_cmd)
+
+        while True:
+            if ffmpeg_jobs.stop_event.is_set():
+                logger.info(f"terminate ffmpeg:{ffmpeg_cmd}")
+                process.terminate()
+                try:
+                    process.communicate(timeout=5)
+                except subprocess.TimeoutExpired:
+                    logger.info(f"terminate timeout,kill")
+                    process.kill()
+
+            if process.poll() is not None:
+                break
+            time.sleep(0.1)
+
+        return_code = process.wait()
+        logger.info(f'ret code:{return_code}')
+        if return_code == 0:
+            with open(DONE_FILE, 'w') as f:
+                pass
+            logger.info(f'ret code:{return_code}, write done file')
+        else:
+            logger.warning(f'ffmpeg error exit, code:{return_code}')
             
             
     @app.route('/api/bilibili/bv/<string:bvid>/dm/<int:seg>', methods=['GET'])
@@ -143,46 +226,50 @@ def add_bv_route(app):
             'dm': list(map(lambda x: x.__dict__, dms))
         })
     
-    def return_bv_stream(bvid, cid):
+    def return_bv_stream(bvid, cid, start_ms=0):
         global ffmpeg_jobs
         v = video.Video(bvid=bvid)
         v_detail = sync(v.get_detail())
         download_url_data = sync(v.get_download_url(cid=cid))
         duration = download_url_data['timelength']
-        output_video_path = f'/tmp/bv_output_{bvid}_{cid}.flv'
+        output_video_path = get_output_video_path(bvid, cid, start_ms)
+        job_key = f'{bvid}_{cid}_{start_ms}'
         
-        if ffmpeg_jobs.bv == bvid + '_' + cid:
+        if ffmpeg_jobs.bv == job_key:
             pass
         else:
-            # stop pre jobs
-            ffmpeg_jobs.stop_event.set()
-            for task in ffmpeg_jobs.tasks:
-                task.join()
+            stop_current_jobs()
             
             # get bv stream
             detecter = video.VideoDownloadURLDataDetecter(data=download_url_data)
             streams = detecter.detect_best_streams(codecs=[video.VideoCodecs.AVC])
             if not detecter.check_video_and_audio_stream():
                 raise Exception(f'can not get video and audio stream by bvid:{bvid}')
-            
-            # create pipe file
-            input_video_pipe = f'/tmp/bv_video_{bvid}_{cid}.m4s'
-            input_audio_pipe = f'/tmp/bv_audio_{bvid}_{cid}.m4s'
-            if os.path.exists(input_video_pipe):
-                os.remove(input_video_pipe)
-            if os.path.exists(input_audio_pipe):
-                os.remove(input_audio_pipe)
-            os.mkfifo(input_video_pipe)
-            os.mkfifo(input_audio_pipe)
-            
-            ffmpeg_jobs.bv = bvid + '_' + cid
+
+            ffmpeg_jobs.bv = job_key
             ffmpeg_jobs.stop_event.clear()
             ffmpeg_jobs.size_map = {}
-            ffmpeg_jobs.tasks = [
-                threading.Thread(target=download_stream, args=(streams[0].url, input_video_pipe)),
-                threading.Thread(target=download_stream, args=(streams[1].url, input_audio_pipe)),
-                threading.Thread(target=ffmpeg, args=(input_video_pipe, input_audio_pipe, output_video_path)),
-            ]
+            if start_ms > 0:
+                ffmpeg_jobs.tasks = [
+                    threading.Thread(
+                        target=ffmpeg_seek_streams,
+                        args=(streams[0].url, streams[1].url, output_video_path, start_ms)
+                    ),
+                ]
+            else:
+                input_video_pipe = f'/tmp/bv_video_{bvid}_{cid}.m4s'
+                input_audio_pipe = f'/tmp/bv_audio_{bvid}_{cid}.m4s'
+                if os.path.exists(input_video_pipe):
+                    os.remove(input_video_pipe)
+                if os.path.exists(input_audio_pipe):
+                    os.remove(input_audio_pipe)
+                os.mkfifo(input_video_pipe)
+                os.mkfifo(input_audio_pipe)
+                ffmpeg_jobs.tasks = [
+                    threading.Thread(target=download_stream, args=(streams[0].url, input_video_pipe)),
+                    threading.Thread(target=download_stream, args=(streams[1].url, input_audio_pipe)),
+                    threading.Thread(target=ffmpeg, args=(input_video_pipe, input_audio_pipe, output_video_path)),
+                ]
             for task in ffmpeg_jobs.tasks:
                 task.start()
         
@@ -202,7 +289,7 @@ def add_bv_route(app):
             time.sleep(CHECK_INTERVAL)
         time.sleep(5)
         size = os.path.getsize(output_video_path)
-        merge_size = sum(ffmpeg_jobs.size_map.values())
+        merge_size = sum(ffmpeg_jobs.size_map.values()) if ffmpeg_jobs.size_map else size
         data = {
             "size": size,
             'merge_size': merge_size,
@@ -219,7 +306,7 @@ def add_bv_route(app):
         response.headers['BV-Duration'] = duration
         
         return response
-    
+
     @app.route('/api/bilibili/bangumi_ss/<string:sid>', methods=['GET'])
     @login_check
     def get_bilibili_bangumi_info(sid):
@@ -314,12 +401,14 @@ def add_bv_route(app):
     @app.route('/api/bilibili/bv/<string:bvid>/<string:cid>/info', methods=['GET'])    
     @login_check
     def get_bilibili_bv_info_stream(bvid, cid):
-        return return_bv_stream(bvid, cid)
+        start_ms = int(request.args.get('start_ms', '0'))
+        return return_bv_stream(bvid, cid, start_ms)
 
     @app.route('/api/bilibili/bv/<string:bvid>/<string:cid>', methods=['GET'])
     @login_check
     def get_bilibili_bv_chunk(bvid, cid):
-        output_video_path = f'/tmp/bv_output_{bvid}_{cid}.flv'
+        start_ms = int(request.args.get('start_ms', '0'))
+        output_video_path = get_output_video_path(bvid, cid, start_ms)
         range_header = request.headers.get('range') # bytes=0-524287
         start, end = range_header.replace('bytes=', '').split('-')
         logger.info(f'get range, start:{start}, end:{end}')
@@ -331,6 +420,11 @@ def add_bv_route(app):
             
         DONE_FILE = f'{output_video_path}.done'
         CHECK_INTERVAL = 0.1  # 检查间隔（秒）
+
+        if not os.path.exists(output_video_path):
+            return_bv_stream(bvid, cid, start_ms)
+        if not wait_for_output_file(output_video_path):
+            return json_fail('Video generation timeout'), 504
         
         final_size = -1
         # wait done or file size > end

--- a/web/public/player.js
+++ b/web/public/player.js
@@ -40,6 +40,7 @@ function Player() {
     this.yLength            = 0;
     this.uvLength           = 0;
     this.beginTimeOffset    = 0;
+    this.streamBaseOffset   = 0;
     this.decoderState       = decoderStateIdle;
     this.playerState        = playerStateIdle;
     this.decoding           = false;
@@ -419,6 +420,7 @@ Player.prototype.stop = function () {
     this.yLength            = 0;
     this.uvLength           = 0;
     this.beginTimeOffset    = 0;
+    this.streamBaseOffset   = 0;
     this.decoderState       = decoderStateIdle;
     this.playerState        = playerStateIdle;
     this.decoding           = false;
@@ -718,6 +720,16 @@ Player.prototype.onOpenDecoder = function (objData) {
         this.logger.logInfo("Decoder ready now.");
         this.startDecoding();
     } else {
+        if (this.isStream) {
+            this.decoderState = decoderStateIdle;
+            this.streamReceivedLen = this.fileInfo ? this.fileInfo.offset : this.streamReceivedLen;
+            this.waitHeaderLength = Math.min(
+                this.streamReceivedLen + this.fileInfo.chunkSize,
+                4 * 1024 * 1024
+            );
+            this.logger.logInfo("Open decoder failed in stream mode, retry with waitHeaderLength " + this.waitHeaderLength + ".");
+            return;
+        }
         this.reportPlayError(objData.e);
     }
 };
@@ -862,7 +874,7 @@ Player.prototype.displayAudioFrame = function (frame) {
 
     if (this.isStream && this.firstAudioFrame) {
         this.firstAudioFrame = false;
-        this.beginTimeOffset = frame.s;
+        this.beginTimeOffset = this.streamBaseOffset + frame.s;
     }
 
     this.pcmPlayer.play(new Uint8Array(frame.d));
@@ -1016,12 +1028,18 @@ Player.prototype.displayLoop = function() {
 Player.prototype.startBuffering = function () {
     this.buffering = true;
     this.showLoading();
+    if (this.isStream) {
+        return;
+    }
     this.pause();
 }
 
 Player.prototype.stopBuffering = function () {
     this.buffering = false;
     this.hideLoading();
+    if (this.isStream) {
+        return;
+    }
     this.resume();
 }
 
@@ -1238,6 +1256,7 @@ Player.prototype.registerVisibilityEvent = function (cb) {
 }
 
 Player.prototype.onStreamDataUnderDecoderIdle = function (length) {
+    this.streamReceivedLen += length;
     if (this.streamReceivedLen >= this.waitHeaderLength) {
         this.logger.logInfo("Opening decoder.");
         this.decoderState = decoderStateInitializing;
@@ -1245,8 +1264,6 @@ Player.prototype.onStreamDataUnderDecoderIdle = function (length) {
             t: kOpenDecoderReq
         };
         this.decodeWorker.postMessage(req);
-    } else {
-        this.streamReceivedLen += length;
     }
 };
 
@@ -1259,8 +1276,16 @@ Player.prototype.requestStream = function (url) {
         var status = 0;
         var reported = false;
 
+        var infoUrl = url;
+        var queryIndex = url.indexOf('?');
+        if (queryIndex >= 0) {
+            infoUrl = url.slice(0, queryIndex) + '/info' + url.slice(queryIndex);
+        } else {
+            infoUrl = url + '/info';
+        }
+
         var xhr = new XMLHttpRequest();
-        xhr.open('get', url + '/info', true);
+        xhr.open('get', infoUrl, true);
         xhr.onreadystatechange = () => {
             var len = xhr.getResponseHeader("BV-Content-Length");
             var dur = xhr.getResponseHeader('BV-Duration');

--- a/web/src/components/BvPlayer.vue
+++ b/web/src/components/BvPlayer.vue
@@ -5,10 +5,10 @@ import { ElMessage } from 'element-plus';
 import { generateSilentWav } from '@/functions/audioUtils';
 
 
-const playerCanvas = ref(null);
-const videoLoading = ref(null);
-const timeTrack = ref(null);
-const timeLabel = ref(null);
+const playerCanvas = ref<HTMLCanvasElement | null>(null);
+const videoLoading = ref<HTMLElement | null>(null);
+const timeTrack = ref<HTMLInputElement | null>(null);
+const timeLabel = ref<HTMLLabelElement | null>(null);
 
 let videoPlayer = shallowRef<any>(null);
 const waitHeaderLength = 512 * 1024 * 1;
@@ -47,6 +47,66 @@ function playOrPause() {
     //     state.isPlay = true;
     //     videoPlayer.resume()
     // }
+}
+
+function getStreamUrl(startMs = 0) {
+    const baseUrl = `/api/bilibili/bv/${state.bvid}/${state.cid}`;
+    if (startMs > 0) {
+        return `${baseUrl}?start_ms=${Math.floor(startMs)}`;
+    }
+    return baseUrl;
+}
+
+function clearDanmuScreen() {
+    const container = document.getElementById('danmu-container');
+    if (container) {
+        container.innerHTML = '';
+    }
+}
+
+function resetDanmuState(startSec = 0) {
+    state.dm_seg = Math.floor(startSec / (6 * 60));
+    state.dms = [];
+    state.processedDmKeys = new Set();
+    clearDanmuScreen();
+}
+
+function loadDanmuForCurrentPosition(startSec = 0) {
+    resetDanmuState(startSec);
+    return get(`/api/bilibili/bv/${state.bvid}/dm/${state.dm_seg}`).then(data => {
+        state.dms = data.dm.filter((dm: any) => dm.dm_time >= startSec);
+    }).catch(() => {
+        state.dms = [];
+    });
+}
+
+function playCurrentVideo(startMs = 0) {
+    const streamUrl = getStreamUrl(startMs);
+    videoPlayer.stop();
+    videoPlayer.play(`stream://${streamUrl}`, playerCanvas.value, function (e: any) {
+        console.error(e);
+        console.error("play error " + e.error + " status " + e.status + ".");
+        if (e.error == 1) {
+            console.info("Finished.");
+        }
+    }, waitHeaderLength, true);
+    videoPlayer.streamBaseOffset = startMs / 1000;
+    videoPlayer.beginTimeOffset = startMs / 1000;
+    if (timeTrack.value) {
+        timeTrack.value.value = String(startMs);
+    }
+    if (timeLabel.value && videoPlayer.displayDuration) {
+        timeLabel.value.innerHTML = `${videoPlayer.formatTime(startMs / 1000)}/${videoPlayer.displayDuration}`;
+    }
+    state.isPlay = true;
+    return loadDanmuForCurrentPosition(startMs / 1000);
+}
+
+function seekVideo(ms: number) {
+    if (!state.bvid || !state.cid) {
+        return;
+    }
+    playCurrentVideo(ms);
 }
 
 interface VideoProps {
@@ -89,37 +149,6 @@ function popDanmu(t: number) {
     );
 }
 
-// function popDanmu(t: number) {
-//     // 创建一个新的数组用于存储需要移除的对象
-//     const toRemove: any[] = [];
-
-//     // 遍历原数组，找到所有 dm_time 小于 t 的对象
-//     for (let i = 0; i < state.dms.length; i++) {
-//         if (state.dms[i].dm_time < t) {
-//             toRemove.push(state.dms[i]); // 将符合条件的对象加入到移除列表
-//         }
-//     }
-    
-//     let showDanmu = toRemove;
-//     if (toRemove.length > 100){
-//         console.warn('弹幕数量大于100，截断');
-//         showDanmu = toRemove.slice(0, 100);
-//     }
-    
-//     for (const danmu of showDanmu){
-//         addDanmu(danmu.text, `#${danmu.color}`);
-//     }
-    
-
-//     // 使用 filter 方法创建一个新数组，过滤掉需要移除的对象
-//     if (toRemove.length > 0){
-//         state.dms = state.dms.filter((item: any) => !toRemove.includes(item));
-//     }
-    
-// }
-
-
-
 onMounted(() => {
     videoPlayer = new Player();
     videoPlayer.setLoadingDiv(videoLoading.value);
@@ -146,41 +175,40 @@ onMounted(() => {
         }
     }).then(url => {
         console.log('url', url);
-        videoPlayer.play(`stream://${url}`, playerCanvas.value, function (e: any) {
-            console.error(e);
-            console.error("play error " + e.error + " status " + e.status + ".");
-            if (e.error == 1) {
-                console.info("Finished.");
-            }
-        }, waitHeaderLength, true);
-        
-        // 加载弹幕
-        state.dm_seg = 0;
-        return get(`/api/bilibili/bv/${state.bvid}/dm/${state.dm_seg}`)
-    }).then(data => {
-        console.log('danmu', data);
-        state.dms = data.dm;
+        return playCurrentVideo(0);
+    }).then(() => {
+        if (timeTrack.value) {
+            timeTrack.value.oninput = (event: Event) => {
+                const target = event.target as HTMLInputElement;
+                if (timeLabel.value && videoPlayer.duration > 0) {
+                    timeLabel.value.innerHTML = `${videoPlayer.formatTime(Number(target.value) / 1000)}/${videoPlayer.displayDuration}`;
+                }
+            };
+            timeTrack.value.onchange = (event: Event) => {
+                const target = event.target as HTMLInputElement;
+                seekVideo(Number(target.value));
+            };
+        }
     })
     ;
     
     videoPlayer.setTimeCallback((t: number) => {
         popDanmu(t);
-        // const seg = t / (6 * 60);
         const seg = Math.floor(t / (6 * 60));
         if (state.dm_seg < seg){
             state.dm_seg = seg;
-            // 在加载新弹幕的请求中
             get(`/api/bilibili/bv/${state.bvid}/dm/${seg}`).then(data => {
                 const newDms = data.dm.filter((dm: any) => 
                     !state.processedDmKeys.has(getDmKey(dm))
                 );
                 state.dms = [...state.dms, ...newDms];
+            }).catch(() => {
+                // Ignore transient danmu failures; playback should continue.
             });
         }
     })
     state.isPlay = true;
 
-    // 生成1分钟静音音频
     const audio:any = document.getElementById("silentAudio");
     const base64SilentAudio = generateSilentWav(60);
     audio.src = 'data:audio/wav;base64,' + base64SilentAudio;
@@ -199,8 +227,8 @@ function addDanmu(danmuText: string, color='#fff') {
     const danmu = document.createElement('div');
     danmu.className = 'danmu';
     danmu.innerText = danmuText;
-    danmu.style.left = `${container.offsetWidth}px`; // 初始位置在右侧外部
-    danmu.style.top = `${Math.random() * (container.offsetHeight * 2 / 3 - 20)}px`; // 随机高度
+    danmu.style.left = `${container.offsetWidth}px`;
+    danmu.style.top = `${Math.random() * (container.offsetHeight * 2 / 3 - 20)}px`;
     danmu.style.color = color
 
     container.appendChild(danmu);
@@ -210,14 +238,20 @@ function addDanmu(danmuText: string, color='#fff') {
 
 function moveDanmu(elem: any, container: any) {
     let pos = parseInt(elem.style.left);
-    const id = setInterval(frame, 50); // 每5ms移动一次
+    const id = setInterval(frame, 50);
 
     function frame() {
-        if (pos < -elem.offsetWidth) { // 如果完全离开左侧
+        if (!elem || !elem.parentNode || !container.contains(elem)) {
             clearInterval(id);
-            elem.parentNode.removeChild(elem); // 删除元素
+            return;
+        }
+        if (pos < -elem.offsetWidth) {
+            clearInterval(id);
+            if (elem.parentNode) {
+                elem.parentNode.removeChild(elem);
+            }
         } else {
-            pos -= 5; // 向左移动
+            pos -= 5;
             elem.style.left = `${pos}px`;
         }
     }
@@ -228,30 +262,9 @@ function switchDanmu(){
 }
 
 function switchEp(ep: any){
-    new Promise((resolve, reject) => {
-        state.bvid = ep.bvid;
-        state.cid = ep.cid;
-        resolve(`/api/bilibili/bv/${ep.bvid}/${ep.cid}`);
-    }).then(url => {
-        console.log('url', url);
-        videoPlayer.stop();
-        videoPlayer.play(`stream://${url}`, playerCanvas.value, function (e: any) {
-            console.error(e);
-            console.error("play error " + e.error + " status " + e.status + ".");
-            if (e.error == 1) {
-                console.info("Finished.");
-            }
-        }, waitHeaderLength, true);
-        
-        // 加载弹幕
-        state.dm_seg = 0;
-        return get(`/api/bilibili/bv/${state.bvid}/dm/${state.dm_seg}`)
-    }).then(data => {
-        console.log('danmu', data);
-        state.dms = data.dm;
-    })
-    ;
-    
+    state.bvid = ep.bvid;
+    state.cid = ep.cid;
+    playCurrentVideo(0);
 }
 
 onUnmounted(() => {
@@ -302,7 +315,6 @@ onUnmounted(() => {
                     <el-button icon="Back" class="btn" size="large" @click="props.onClose" circle />
                     <el-button icon="ChatLineRound" class="btn" size="large" @click="switchDanmu" circle></el-button>
                     <el-text class="bv-title" size="large">{{ state.title }}</el-text>
-                    <!-- <el-text class="bv-desc" truncated size="small">{{ state.desc }}</el-text> -->
                 </el-col>
             </el-row>
             <el-row justify="start">


### PR DESCRIPTION
## What changed
Fix Bilibili stream seek so clicking the progress bar actually jumps and playback stays aligned after the jump.

## Why
The Bilibili player used a stream-transcode flow that did not support seek, and the frontend stream player had several state bugs after restarting playback from a seek position.

## Impact
Users can now click the Bilibili progress bar to jump, the displayed playback time no longer snaps back to zero after seek, and transient danmu failures no longer break playback.

## Root cause
The original implementation streamed a single live transcode without a seek entry point. After adding seek restarts, the player still had URL assembly issues, early decoder-open timing, stream buffering behavior that called stop in stream mode, and a first-audio-frame offset overwrite that reset the tracked playback position.

## Validation
- `python3 -m py_compile ffvideo/bv.py`
- `npm run type-check`
- `npm run build-only`
- Manual local testing of Bilibili seek, repeated seek retries, and post-seek progress updates
